### PR TITLE
Add additional log line to help separate multiple missions when debuging

### DIFF
--- a/Patches/Contract.cs
+++ b/Patches/Contract.cs
@@ -9,14 +9,15 @@ namespace DropCostsEnhanced.Patches
 {
     [HarmonyPatch(typeof(Contract), "CompleteContract")]
     public static class Contract_CompleteContract_Patch {
-        
+
         static void Postfix(Contract __instance)
         {
             try
             {
-                CombatGameState combat = __instance.BattleTechGame.Combat; 
+                CombatGameState combat = __instance.BattleTechGame.Combat;
+                DCECore.modLog.Info?.Write($"Calculating Drop Cost for {__instance.Name}. Original MoneyResults: {__instance.MoneyResults}");
                 List<AbstractActor> actors = combat.AllActors;
-                
+
 
                 int TotalCost = 0;
                 if (DCECore.settings.enableDropCosts)
@@ -36,7 +37,7 @@ namespace DropCostsEnhanced.Patches
 
                 int newResult = Mathf.FloorToInt(__instance.MoneyResults - TotalCost);
                 Traverse.Create(__instance).Property("MoneyResults").SetValue(newResult);
-                
+
 
 
             }


### PR DESCRIPTION
Looking through the DCE logs, it would be a bit easier to read if they included the mission name associated with each calculation.