### PR TITLE
allow difficulty icon and icon background overrides in `diffWidgetRungs`

### DIFF
--- a/Data/DifficultyWidgetLevel.cs
+++ b/Data/DifficultyWidgetLevel.cs
@@ -1,16 +1,25 @@
+using BattleTech;
+using BattleTech.Data;
 using UnityEngine;
 using Newtonsoft.Json;
+using SVGImporter;
 
 namespace DropCostsEnhanced.Data
 {
     public class DifficultyWidgetLevel
     {
         public string colour = "#FF00FF";
+        public string iconOverride = "";
+        public string iconBackingOverride = "";
         public int rung = 1;
         
         private Color refColor;
         private bool cSet = false;
-        
+
+        private SVGAsset iconOverrideAsset;
+        private SVGAsset iconBackingOverrideAsset;
+        private bool iSet = false;
+        private bool bSet = false;
         
         public Color GetColor()
         {
@@ -22,5 +31,26 @@ namespace DropCostsEnhanced.Data
             return refColor;
         }
 
+        public SVGAsset GetIconAsset()
+        {
+            if (!iSet)
+            {
+                DataManager dm = UnityGameInstance.BattleTechGame.DataManager;
+                iconOverrideAsset = dm.GetObjectOfType<SVGAsset>(iconOverride, BattleTechResourceType.SVGAsset);
+                iSet = true;
+            }
+            return iconOverrideAsset;
+        }
+
+        public SVGAsset GetIconBackingAsset()
+        {
+            if (!bSet)
+            {
+                DataManager dm = UnityGameInstance.BattleTechGame.DataManager;
+                iconBackingOverrideAsset = dm.GetObjectOfType<SVGAsset>(iconBackingOverride, BattleTechResourceType.SVGAsset);
+                bSet = true;
+            }
+            return iconBackingOverrideAsset;
+        }
     }
 }

--- a/Data/DifficultyWidgetLevel.cs
+++ b/Data/DifficultyWidgetLevel.cs
@@ -33,7 +33,7 @@ namespace DropCostsEnhanced.Data
 
         public SVGAsset GetIconAsset()
         {
-            if (!iSet)
+            if (!iSet && !string.IsNullOrEmpty(iconOverride))
             {
                 DataManager dm = UnityGameInstance.BattleTechGame.DataManager;
                 iconOverrideAsset = dm.GetObjectOfType<SVGAsset>(iconOverride, BattleTechResourceType.SVGAsset);
@@ -44,7 +44,7 @@ namespace DropCostsEnhanced.Data
 
         public SVGAsset GetIconBackingAsset()
         {
-            if (!bSet)
+            if (!bSet && ! string.IsNullOrEmpty(iconBackingOverride))
             {
                 DataManager dm = UnityGameInstance.BattleTechGame.DataManager;
                 iconBackingOverrideAsset = dm.GetObjectOfType<SVGAsset>(iconBackingOverride, BattleTechResourceType.SVGAsset);

--- a/Data/Settings.cs
+++ b/Data/Settings.cs
@@ -3,6 +3,7 @@ using BattleTech;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using SVGImporter;
 using UnityEngine;
 
 namespace DropCostsEnhanced.Data
@@ -101,6 +102,40 @@ namespace DropCostsEnhanced.Data
                 }
             }
 
+            return false;
+        }
+
+        public bool getRungIcon(int rung, out SVGAsset asset)
+        {
+            asset = null;
+            if (useDiffRungs)
+            {
+                foreach (DifficultyWidgetLevel diffRung in diffWidgetRungs)
+                {
+                    if (diffRung.rung == rung)
+                    {
+                        asset = diffRung.GetIconAsset();
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public bool getRungBackingIcon(int rung, out SVGAsset asset)
+        {
+            asset = null;
+            if (useDiffRungs)
+            {
+                foreach (DifficultyWidgetLevel diffRung in diffWidgetRungs)
+                {
+                    if (diffRung.rung == rung)
+                    {
+                        asset = diffRung.GetIconBackingAsset();
+                        return true;
+                    }
+                }
+            }
             return false;
         }
     }

--- a/Features/DifficultyManager.cs
+++ b/Features/DifficultyManager.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System;
 using DropCostsEnhanced.Data;
 using System.Linq;
+using BattleTech.Data;
+using SVGImporter;
 using UnityEngine;
 
 namespace DropCostsEnhanced

--- a/Patches/SGDifficultyIndicatorWidget.cs
+++ b/Patches/SGDifficultyIndicatorWidget.cs
@@ -7,6 +7,8 @@ using DropCostsEnhanced.Data;
 using UnityEngine;
 using SVGImporter;
 using System.Collections.Generic;
+using System.Net.Mime;
+using UnityEngine.UI;
 
 
 namespace DropCostsEnhanced.Patches
@@ -39,12 +41,35 @@ namespace DropCostsEnhanced.Patches
 
             int index;
             Color color;
+            SVGAsset asset;
+            SVGAsset assetBacking;
             bool customColor = DCECore.settings.getRungColor(Math.Max((difficulty - 1) / 10, 0), out color);
+            bool customAsset = DCECore.settings.getRungIcon(Math.Max((difficulty - 1) / 10, 0), out asset);
+            bool customAssetBacking = DCECore.settings.getRungBackingIcon(Math.Max((difficulty - 1) / 10, 0), out assetBacking);
+            if (customAsset)
+            {
+                HorizontalLayoutGroup[] backingComponents = __instance.GetComponentsInChildren<HorizontalLayoutGroup>();
+                for (int i = 0; i < backingComponents.Length; i++)
+                {
+                    if (backingComponents[i].name == "pip-backings")
+                    {
+                        SVGImage[] backingImages = backingComponents[i].GetComponentsInChildren<SVGImage>();
+                        for (int j = 0; j < backingImages.Length; j++)
+                        {
+                            backingImages[j].GetComponent<SVGImage>().vectorGraphics = assetBacking;
+                        }
+                    }
+                }
+            }
             for (index = 0; index < Mathf.FloorToInt(f); ++index)
             {
                 UIColorRefTracker pip = ___pips[index];
                 pip.GetComponent<SVGImage>().fillAmount = 1f;
-                
+                if (customAsset)
+                {
+                    SVGImage svgImage = pip.GetComponent<SVGImage>();
+                    svgImage.vectorGraphics = asset;
+                }
                 if (customColor)
                 {
                     pip.SetUIColor(UIColor.Custom);
@@ -59,7 +84,11 @@ namespace DropCostsEnhanced.Patches
                 return false;
             UIColorRefTracker pip1 = ___pips[index];
             SVGImage component = pip1.GetComponent<SVGImage>();
-            
+            if (customAsset)
+            {
+                SVGImage svgImage = pip1.GetComponent<SVGImage>();
+                svgImage.vectorGraphics = asset;
+            }
             if (customColor)
             {
                 pip1.SetUIColor(UIColor.Custom);

--- a/Patches/SGDifficultyIndicatorWidget.cs
+++ b/Patches/SGDifficultyIndicatorWidget.cs
@@ -46,7 +46,7 @@ namespace DropCostsEnhanced.Patches
             bool customColor = DCECore.settings.getRungColor(Math.Max((difficulty - 1) / 10, 0), out color);
             bool customAsset = DCECore.settings.getRungIcon(Math.Max((difficulty - 1) / 10, 0), out asset);
             bool customAssetBacking = DCECore.settings.getRungBackingIcon(Math.Max((difficulty - 1) / 10, 0), out assetBacking);
-            if (customAsset)
+            if (customAssetBacking)
             {
                 HorizontalLayoutGroup[] backingComponents = __instance.GetComponentsInChildren<HorizontalLayoutGroup>();
                 for (int i = 0; i < backingComponents.Length; i++)

--- a/Patches/SimGameState.cs
+++ b/Patches/SimGameState.cs
@@ -7,6 +7,8 @@ using DropCostsEnhanced.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BattleTech.Data;
+using SVGImporter;
 using UnityEngine;
 
 namespace DropCostsEnhanced.Patches
@@ -18,6 +20,19 @@ namespace DropCostsEnhanced.Patches
         public static void Postfix(SimGameState __instance, GameInstanceSave gameInstanceSave)
         {
             DifficultyManager.Instance.setCompanyStats(__instance);
+            if (DCECore.settings.useDiffRungs)
+            {
+                DataManager dm = UnityGameInstance.BattleTechGame.DataManager;
+                LoadRequest loadRequest = dm.CreateLoadRequest();
+                foreach (var rung in DCECore.settings.diffWidgetRungs)
+                {
+                    if (!string.IsNullOrEmpty(rung.iconOverride)) loadRequest.AddLoadRequest<SVGAsset>(BattleTechResourceType.SVGAsset, rung.iconOverride,
+                        null);
+                    if (!string.IsNullOrEmpty(rung.iconBackingOverride)) loadRequest.AddLoadRequest<SVGAsset>(BattleTechResourceType.SVGAsset, rung.iconBackingOverride,
+                        null);
+                }
+                loadRequest.ProcessRequests();
+            }
         }
     }
 
@@ -27,6 +42,19 @@ namespace DropCostsEnhanced.Patches
         public static void Postfix(SimGameState __instance)
         {
             DifficultyManager.Instance.setCompanyStats(__instance);
+            if (DCECore.settings.useDiffRungs)
+            {
+                DataManager dm = UnityGameInstance.BattleTechGame.DataManager;
+                LoadRequest loadRequest = dm.CreateLoadRequest();
+                foreach (var rung in DCECore.settings.diffWidgetRungs)
+                {
+                    if (!string.IsNullOrEmpty(rung.iconOverride)) loadRequest.AddLoadRequest<SVGAsset>(BattleTechResourceType.SVGAsset, rung.iconOverride,
+                        null);
+                    if (!string.IsNullOrEmpty(rung.iconBackingOverride)) loadRequest.AddLoadRequest<SVGAsset>(BattleTechResourceType.SVGAsset, rung.iconBackingOverride,
+                        null);
+                }
+                loadRequest.ProcessRequests();
+            }
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -106,13 +106,19 @@ This was inspired by the original drop cost mod: `DropCostPerMech` and `GlobalDi
 ```json
 {
     "rung" : 1,
-    "colour" : "#e6210b"
+    "colour" : "#e6210b",
+    "iconOverride": "edited",
+		"iconBackingOverride": "edited"
 }
 ```
 
 `rung` : the rung level that this colour should be applied to, each rung level represents a set of 5 skulls, starting with rung level 0, which represents 0.5 - 5 skulls, rung level 1 5.5 - 10 skulls, etc
 
 `colour` : an html colour code, the colour to be applied for this rung level
+
+`iconOverride` : string name of SVG asset which will override the vanilla atlas skull for difficulty indicators
+
+`iconBackingOverride` : string name of SVG asset which will override the vanilla atlas skull which is the shaded grey background for the "unfilled" difficulty indicators. vanilla behavior would be set to the same as `iconOverride` (same shape), but you can define a different background if you want.
 
 ## Drop Costs
 


### PR DESCRIPTION
both `iconOverride` and `iconBackingOverride` can be undefined or empty string to show the vanilla atlas skull, otherwise will accept any SVG asset. set both to be the same so the shaded backing is the same "shape" icon as the difficulty icon
```
"diffWidgetRungs": [
		{
			"rung": 0,
			"colour": "#25CC00",
			"iconOverride": "edited",
			"iconBackingOverride": "passive-ab"
		}
	]
```